### PR TITLE
[FEAT] Timeline Added & Profile Image Functionality Added

### DIFF
--- a/components/Metadata.js
+++ b/components/Metadata.js
@@ -8,8 +8,10 @@ export default function Metadata(props) {
       <Head>
         <meta name="theme-color" content="#34ac54 " />
         <meta name="description" content="Christmas Throwdown Website" />
+        <link rel="apple-touch-icon" href="images/antidote_logo.png" />
         <meta name="author" content="Faris Aziz"></meta>
         <title>{title}</title>
+        <link rel="manifest" href="manifest.json" />
         <link rel="icon" href="/favicon.ico" />
         <link
           rel="stylesheet"

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { useRouter } from "next/router";
 import { useAuth } from "../hooks/useAuth";
 import Link from "next/link";
 import styles from "../styles/Navbar.module.css";
@@ -6,6 +7,7 @@ import styles from "../styles/Navbar.module.css";
 export default function Navbar() {
   const [currentPage, setCurrentPage] = useState("/");
   const auth = useAuth();
+  const router = useRouter()
 
   useEffect(() => {
     setCurrentPage(window.location.pathname);
@@ -121,7 +123,10 @@ export default function Navbar() {
           </ul>
           {auth.user ? (
             <button
-              onClick={auth.signOut}
+              onClick={() => {
+                auth.signOut()
+                router.push("/")
+              }}
               className="btn btn-outline-secondary my-2 my-sm-0"
             >
               Logout

--- a/components/Timeline.js
+++ b/components/Timeline.js
@@ -1,0 +1,32 @@
+import React from "react";
+import styles from "../styles/Timeline.module.css";
+import { timelineContent } from "../content/timeline";
+
+export default function Timeline() {
+  return (
+    <div>
+      <div className={styles.page}>
+        <div className={styles.timeline}>
+          <div className={styles.timelinegroup}>
+            <span className={styles.timelineyear}>
+              Saturday 5th December 2020
+            </span>
+            {timelineContent.map((event) => (
+              <div className={styles.timelinebox}>
+                <div className={styles.timelinedate}>
+                  <span className={styles.timelineday}>{event.time}</span>
+                  <span className={styles.timelinemonth}>Event</span>
+                </div>
+                <div className={styles.timelinepost}>
+                  <div className={styles.timelinecontent}>
+                    <p>{event.event}</p>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/content/timeline.js
+++ b/content/timeline.js
@@ -1,0 +1,90 @@
+const timelineContent = [
+  {
+    time: "9:45",
+    event: "Check-in.",
+  },
+  {
+    time: "10:00",
+    event: "General Day Brief + Event 1 Brief.",
+  },
+  {
+    time: "10:10",
+    event: "Guided Warm up Session.",
+  },
+  {
+    time: "10:30",
+    event: "Event 1: Heat 1",
+  },
+  {
+    time: "10:55",
+    event: "Event 1: Heat 2",
+  },
+  {
+    time: "11:20",
+    event: "Event 1: Heat 3",
+  },
+  {
+    time: "11:45",
+    event: "Guided Cool Down Mobility Session.",
+  },
+  {
+    time: "11:55",
+    event: "Event 2 Brief + Guided Warm up.",
+  },
+  {
+    time: "12:10",
+    event: "Event 2: Heat 1",
+  },
+  {
+    time: "12:35",
+    event: "Event 2: Heat 2",
+  },
+  {
+    time: "13:00",
+    event: "Event 2: Heat 3",
+  },
+  {
+    time: "13:20",
+    event: "Lunch Break (Every team gets ~70 Min).",
+  },
+  {
+    time: "13:40",
+    event: "Event 3 Brief.",
+  },
+  {
+    time: "13:50",
+    event: "Guided Mobility Session.",
+  },
+  {
+    time: "14:00",
+    event: "Guided Warm up Session.",
+  },
+  {
+    time: "14:15",
+    event: "Event 3: Heat 1",
+  },
+  {
+    time: "14:30",
+    event: "Event 3: Heat 2",
+  },
+  {
+    time: "14:55",
+    event: "Event 3: Heat 3",
+  },
+  {
+    time: "15:20",
+    event: "Short Break.",
+  },
+  {
+    time: "15:30",
+    event: "Christmas & Birthday Celebration.",
+  },
+  {
+    time: "16:00",
+    event: "Results, Prizes & Closing Remarks",
+  },
+];
+
+module.exports = {
+  timelineContent,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "my-app",
+  "name": "xmas-throwdown",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/pages/login.js
+++ b/pages/login.js
@@ -32,7 +32,7 @@ export default function login() {
   const { register, handleSubmit } = useForm();
 
   useEffect(() => {
-    app.auth().onAuthStateChanged(function (user) {
+    app.auth().onAuthStateChanged((user) => {
       if (user) {
         setUser(user);
       }
@@ -84,7 +84,7 @@ export default function login() {
   };
 
   if (user) {
-    router.push("/");
+    router.back();
   }
   const formComplete =
     firstName &&

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -1,0 +1,48 @@
+import React, { useState, useEffect } from "react";
+import styles from "../styles/Home.module.css";
+import NavBar from "../components/Navbar";
+import Footer from "../components/Footer";
+import Metadata from "../components/Metadata";
+import { app } from "../config/firebase";
+import { useAuth } from "../hooks/useAuth";
+import { useRouter } from "next/router";
+
+export default function profile({user}) {
+    // const [currentUser, setCurrentUser] = useState(undefined);
+  const auth = useAuth();
+  const router = useRouter();
+
+  profile.getInitialProps = async () => {
+    return { user: auth.user };
+  };
+
+  // useEffect(() => {
+  //   setCurrentUser(user)
+  // }, [user]);
+
+  // console.log(currentUser)
+
+  if (user) {
+    return (
+      <div className={styles.container}>
+        <Metadata title={"Xmas Throwdown Profile"} />
+        <NavBar />
+        <main className={styles.main}>
+          <h1 className={styles.fontandcenter}>Profile</h1>
+        </main>
+        <Footer />
+      </div>
+    );
+  } else {
+    if (typeof window !== "undefined" && !user) {
+      router.push("/login");
+    }
+    return (
+      <div className={styles.container}>
+        <div className="spinner-border text-success" role="status">
+          <span className="sr-only">Loading...</span>
+        </div>
+      </div>
+    );
+  }
+}

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -1,26 +1,50 @@
 import React, { useState, useEffect } from "react";
+import { useAuth } from "../hooks/useAuth";
+import { useRouter } from "next/router";
 import styles from "../styles/Home.module.css";
 import NavBar from "../components/Navbar";
 import Footer from "../components/Footer";
 import Metadata from "../components/Metadata";
-import { app } from "../config/firebase";
-import { useAuth } from "../hooks/useAuth";
-import { useRouter } from "next/router";
 
-export default function profile({user}) {
-    // const [currentUser, setCurrentUser] = useState(undefined);
+const altImage = "https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fmedicine.fiu.edu%2Fabout%2Ffaculty-and-staff%2Fpeople%2F_assets%2Fprofiles%2Fheadshot-placeholder.png&f=1&nofb=1"
+
+export default function profile({user, userInfo}) {
+  const [imagePreviewUrl, setImagePreviewUrl] = useState(userInfo&& userInfo.image? userInfo.image : altImage)
   const auth = useAuth();
   const router = useRouter();
 
   profile.getInitialProps = async () => {
-    return { user: auth.user };
+    if (auth.user){
+      const details = await fetch(`https://wod-with-faris-backend.herokuapp.com/user/getuser?email=${auth.user.email}`)
+      .then(resp => resp.json())
+      return { user: auth.user, userInfo: details};
+    }
+    return {}
   };
 
-  // useEffect(() => {
-  //   setCurrentUser(user)
-  // }, [user]);
+  const fileChangedHandler = event => {
 
-  // console.log(currentUser)
+    let reader = new FileReader();
+      reader.onloadend = () => {
+        setImagePreviewUrl(reader.result)
+        uploadImage(reader.result)
+    }
+    reader.readAsDataURL(event.target.files[0])
+  }
+
+  const uploadImage = async image => {
+    const user = await fetch("https://wod-with-faris-backend.herokuapp.com/user/store_profile_img", {
+      method: "POST",
+      headers: { 
+        "Content-type": "application/json"
+      },
+      body: JSON.stringify({ 
+        img: image,
+        user_id: userInfo.id
+    })
+    }).then(resp => resp.json())
+    setImagePreviewUrl(user.image)
+  }
 
   if (user) {
     return (
@@ -28,7 +52,14 @@ export default function profile({user}) {
         <Metadata title={"Xmas Throwdown Profile"} />
         <NavBar />
         <main className={styles.main}>
-          <h1 className={styles.fontandcenter}>Profile</h1>
+          <h1 className={styles.fontandcenter}>Hey {userInfo.first_name}!</h1>
+            <div className="center-item">
+              <img style={{ borderRadius: "100px", width: "150px", height: "150px"}} src={imagePreviewUrl} alt="..."/>
+            </div>
+              <input className="center-item" id="profile-img" type="file" style={{display: "none"}} name="avatar" onChange={fileChangedHandler} />
+              <label className={styles["change-img-btn"]} for="profile-img">
+                Change Image
+              </label>
         </main>
         <Footer />
       </div>

--- a/pages/schedule.js
+++ b/pages/schedule.js
@@ -3,6 +3,7 @@ import styles from "../styles/Home.module.css";
 import NavBar from "../components/Navbar";
 import Footer from "../components/Footer";
 import Metadata from "../components/Metadata";
+import Timeline from "../components/Timeline";
 
 export default function schedule() {
   return (
@@ -10,7 +11,18 @@ export default function schedule() {
       <Metadata title={"Xmas Throwdown Schedule"} />
       <NavBar />
       <main className={styles.main}>
-        <h1>Schedule</h1>
+        <h1 className={styles.fontandcenter}>Schedule</h1>
+
+        <a
+          href="webcal://p27-caldav.icloud.com/published/2/MTA3MjYwMjc5ODEwNzI2MA9IJFarAqnTo7xa5pBvkRvGndO0stiLebpRdRahEJdG_TUdlADHB45OxCuXqdvIw7fmnIQnw_08rf_lrLBBDog"
+          target="_blank"
+        >
+          <button type="button" className="btn btn-dark topspace">
+            Subscribe to the Event Calendar
+          </button>
+        </a>
+
+        <Timeline />
       </main>
       <Footer />
     </div>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,25 @@
+{
+  "short_name": "Xmas Throwdown",
+  "name": "Xmas Throwdown",
+  "icons": [
+    {
+      "src": "favicon.ico",
+      "sizes": "64x64 32x32 24x24 16x16",
+      "type": "image/x-icon"
+    },
+    {
+      "src": "/images/antidote_logo.png",
+      "type": "image/png",
+      "sizes": "192x192"
+    },
+    {
+      "src": "/images/antidote_logo.png",
+      "type": "image/png",
+      "sizes": "512x512"
+    }
+  ],
+  "start_url": ".",
+  "display": "standalone",
+  "theme_color": "#34ac54",
+  "background_color": "#ffffff"
+}

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -135,6 +135,17 @@
   height: 2em;
 }
 
+.change-img-btn {
+  margin-top: 2%;
+  padding: 4px 4px 4px;
+  border-radius: 5px;
+  background-color: lightgray;
+}
+
+.change-img-btn:hover {
+  background-color: gray;
+}
+
 @media (max-width: 600px) {
   .grid {
     width: 100%;

--- a/styles/Timeline.module.css
+++ b/styles/Timeline.module.css
@@ -1,0 +1,151 @@
+.timeline {
+  --uiTimelineMainColor: var(--timelineMainColor, #222);
+  --uiTimelineSecondaryColor: var(--timelineSecondaryColor, #fff);
+
+  position: relative;
+  padding-top: 3rem;
+  padding-bottom: 3rem;
+}
+
+.timeline:before {
+  content: "";
+  width: 4px;
+  height: 100%;
+  background-color: var(--uiTimelineMainColor);
+
+  position: absolute;
+  top: 0;
+}
+
+.timelinegroup {
+  position: relative;
+}
+
+.timelinegroup:not(:first-of-type) {
+  margin-top: 4rem;
+}
+
+.timelineyear {
+  padding: 0.5rem 1.5rem;
+  color: var(--uiTimelineSecondaryColor);
+  background-color: var(--uiTimelineMainColor);
+
+  position: absolute;
+  left: 0;
+  top: 0;
+}
+
+.timelinebox {
+  position: relative;
+}
+
+.timelinebox:not(:last-of-type) {
+  margin-bottom: 30px;
+}
+
+.timelinebox:before {
+  content: "";
+  width: 100%;
+  height: 2px;
+  background-color: var(--uiTimelineMainColor);
+
+  position: absolute;
+  left: 0;
+  z-index: -1;
+}
+
+.timelinedate {
+  margin-top: 2%;
+  max-height: 80px;
+  position: absolute;
+  left: 0;
+
+  box-sizing: border-box;
+  padding: 0.5rem 1.5rem;
+  text-align: center;
+
+  border: solid 1px white;
+
+  background-color: var(--uiTimelineMainColor);
+  color: var(--uiTimelineSecondaryColor);
+}
+
+.timelineday {
+  font-size: 1rem;
+  font-weight: 700;
+  display: block;
+}
+
+.timelinemonth {
+  display: block;
+  font-size: 0.8em;
+  text-transform: uppercase;
+}
+
+.timelinepost {
+  padding: 0.5rem 2rem;
+  border-radius: 2px;
+  border-left: 3px solid var(--uiTimelineMainColor);
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.12), 0 1px 2px 0 rgba(0, 0, 0, 0.24);
+  background-color: var(--uiTimelineSecondaryColor);
+}
+
+@media screen and (min-width: 641px) {
+  .timeline:before {
+    left: 30px;
+  }
+
+  .timelinegroup {
+    padding-top: 55px;
+  }
+
+  .timelinebox {
+    padding-left: 80px;
+  }
+
+  .timelinebox:before {
+    top: 50%;
+    transform: translateY(-50%);
+  }
+
+  .timelinedate {
+    top: 50%;
+    margin-top: -27px;
+  }
+}
+
+@media screen and (max-width: 640px) {
+  .timeline:before {
+    left: 0;
+  }
+
+  .timelinegroup {
+    padding-top: 40px;
+  }
+
+  .timelinebox {
+    padding-left: 20px;
+    padding-top: 70px;
+  }
+
+  .timelinebox:before {
+    top: 90px;
+  }
+
+  .timelinedate {
+    top: 0;
+  }
+}
+
+.timeline {
+  --timelineMainColor: #34ac54;
+  font-size: 16px;
+}
+
+.page {
+  max-width: 800px;
+  padding: 1rem 2rem 3rem;
+  margin-left: auto;
+  margin-right: auto;
+  order: 1;
+}


### PR DESCRIPTION
# Description

Timeline added to schedule page and users are now able to upload photos in their profile page.


## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)


## Screenshots

`Desktop:`

`Profile Page:`
<img width="1436" alt="Screenshot 2020-10-17 at 23 41 23" src="https://user-images.githubusercontent.com/53216647/96354111-3cda1080-10d3-11eb-92d6-a4388b5eb084.png">

`Schedule Page:`
<img width="1435" alt="Screenshot 2020-10-17 at 23 47 07" src="https://user-images.githubusercontent.com/53216647/96354115-45cae200-10d3-11eb-8318-106b377e5324.png">


`Mobile (iPhone 5):`

`Profile Page:`
<img width="326" alt="Screenshot 2020-10-17 at 23 41 48" src="https://user-images.githubusercontent.com/53216647/96354125-5bd8a280-10d3-11eb-8b8d-866f73cc1908.png">


`Schedule Page:`
<img width="319" alt="Screenshot 2020-10-17 at 23 46 59" src="https://user-images.githubusercontent.com/53216647/96354129-5f6c2980-10d3-11eb-9ee3-21566e8ed0d4.png">


# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

